### PR TITLE
Ease setup for Android & Xcode

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     ext {
         buildToolsVersion = "29.0.2"
         minSdkVersion = 21
-        compileSdkVersion = 31
+        compileSdkVersion = 29
         targetSdkVersion = 29
     }
     repositories {

--- a/ios/AdaloApp.xcodeproj/project.pbxproj
+++ b/ios/AdaloApp.xcodeproj/project.pbxproj
@@ -1453,7 +1453,6 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "af7bfe36-5c33-401a-8b37-0f147752b2aa";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.adalo.app";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AdaloApp.app/AdaloApp";
 			};
@@ -1532,7 +1531,6 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.adalo.app;
 				PRODUCT_NAME = "Adalo App";
-				PROVISIONING_PROFILE = "af7bfe36-5c33-401a-8b37-0f147752b2aa";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "AdaloApp-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -1614,7 +1612,6 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.facebook.REACT.AdaloApp-tvOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "af7bfe36-5c33-401a-8b37-0f147752b2aa";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.adalo.app";
 				SDKROOT = appletvos;
 				TARGETED_DEVICE_FAMILY = 3;
@@ -1694,7 +1691,6 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.facebook.REACT.AdaloApp-tvOSTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "af7bfe36-5c33-401a-8b37-0f147752b2aa";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.adalo.app";
 				SDKROOT = appletvos;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AdaloApp-tvOS.app/AdaloApp-tvOS";

--- a/ios/AdaloApp.xcodeproj/project.pbxproj
+++ b/ios/AdaloApp.xcodeproj/project.pbxproj
@@ -767,9 +767,8 @@
 						TestTargetID = 13B07F861A680F5B00A75B9A;
 					};
 					13B07F861A680F5B00A75B9A = {
-						DevelopmentTeam = 4T38369F9B;
 						LastSwiftMigration = 1150;
-						ProvisioningStyle = Manual;
+						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
 							com.apple.Push = {
 								enabled = 1;
@@ -1466,11 +1465,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_ENTITLEMENTS = AdaloApp/AdaloApp.entitlements;
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 3;
 				DEAD_CODE_STRIPPING = NO;
-				DEVELOPMENT_TEAM = 4T38369F9B;
+				DEVELOPMENT_TEAM = "";
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../node_modules/react-native-image-picker/ios",
@@ -1507,11 +1506,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_ENTITLEMENTS = AdaloApp/AdaloApp.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 3;
-				DEVELOPMENT_TEAM = 4T38369F9B;
+				DEVELOPMENT_TEAM = "";
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../node_modules/react-native-image-picker/ios",
@@ -1535,7 +1533,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.adalo.app;
 				PRODUCT_NAME = "Adalo App";
 				PROVISIONING_PROFILE = "af7bfe36-5c33-401a-8b37-0f147752b2aa";
-				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.adalo.app";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "AdaloApp-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "test": "jest",
     "bundle:android": "react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res && rm -rf android/app/src/main/res/drawable-*/src* && rm -rf android/app/src/main/res/drawable-*/node_modules* && rm -rf android/app/src/main/res/drawable-*/images_*",
-    "postinstall": "node scripts/excludePackages.js $(pwd)/node_modules"
+    "postinstall": "jetify && node scripts/excludePackages.js $(pwd)/node_modules"
   },
   "dependencies": {
     "@protonapp/material-components": "https://component-marketplace-prod.s3.amazonaws.com/@protonapp/material-components/0.8.17.tar",
@@ -51,6 +51,7 @@
     "aws-sdk": "^2.415.0",
     "babel-jest": "^25.1.0",
     "jest": "^25.1.0",
+    "jetifier": "^2.0.0",
     "metro-react-native-babel-preset": "^0.59.0",
     "react-test-renderer": "16.13.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5182,6 +5182,11 @@ jetifier@^1.6.2:
   resolved "https://registry.yarnpkg.com/jetifier/-/jetifier-1.6.6.tgz#fec8bff76121444c12dc38d2dad6767c421dab68"
   integrity sha512-JNAkmPeB/GS2tCRqUzRPsTOHpGDah7xP18vGJfIjZC+W2sxEHbxgJxetIjIqhjQ3yYbYNEELkM/spKLtwoOSUQ==
 
+jetifier@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/jetifier/-/jetifier-2.0.0.tgz#699391367ca1fe7bc4da5f8bf691eb117758e4cb"
+  integrity sha512-J4Au9KuT74te+PCCCHKgAjyLlEa+2VyIAEPNCdE5aNkAJ6FAJcAqcdzEkSnzNksIa9NkGmC4tPiClk2e7tCJuQ==
+
 jmespath@0.15.0:
   version "0.15.0"
   resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"


### PR DESCRIPTION
This pull request aims to streamline setup for Xcode & Android

### Android
Ensure users can simply execute `yarn install && yarn start` and `react-native run-android` without error. By:

1. Ensuring appropriate compile SDK is provided
2. Ensuring annotations are provided by Jetifier to packages like rn-firebase

### Xcode
Ease setup for new devs by only requiring them to select their team in Xcode before their first build.

This pull request nullifies some values in the Xcode project so that Automatic signing is enabled and so that the user is only prompted to select their team.

Admittedly, I don't know what best practices are here, but this eased the setup flow for me when first cloning the project.