### PR TITLE
Adding missing supportLibVersion line, that was breaking some builds.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,6 +7,7 @@ buildscript {
         compileSdkVersion = 29
         targetSdkVersion = 29
         firebaseMessagingVersion = "21.1.0"
+        supportLibVersion = "29.0.0"
     }
     repositories {
         google()


### PR DESCRIPTION
Added a missing line that defines the supported Android library, which was breaking some builds that required manually linking the project as part of the installation process.